### PR TITLE
Fix Domain Compilation Warnings and Errors

### DIFF
--- a/src/IslamicPOS.Domain/Common/AuditableEntity.cs
+++ b/src/IslamicPOS.Domain/Common/AuditableEntity.cs
@@ -3,7 +3,7 @@ namespace IslamicPOS.Domain.Common
     public abstract class AuditableEntity : Entity
     {
         public DateTime Created { get; set; }
-        public string? CreatedBy { get; set; }
+        public new string? CreatedBy { get; set; } // Use 'new' keyword
         public DateTime? LastModified { get; set; }
         public string? LastModifiedBy { get; set; }
     }

--- a/src/IslamicPOS.Domain/Sales/Sale.cs
+++ b/src/IslamicPOS.Domain/Sales/Sale.cs
@@ -1,4 +1,4 @@
-﻿using IslamicPOS.Domain.Common;
+using IslamicPOS.Domain.Common;
 
 namespace IslamicPOS.Domain.Sales;
 
@@ -31,7 +31,8 @@ public class Sale : EntityBase
         var total = Money.Zero(Items.First().UnitPrice.Currency);
         foreach (var item in Items)
         {
-            total += new Money(item.UnitPrice.Amount * item.Quantity, item.UnitPrice.Currency);
+            // Use Amount property for addition
+            total = new Money(total.Amount + (item.UnitPrice.Amount * item.Quantity), item.UnitPrice.Currency);
         }
         TotalAmount = total;
     }


### PR DESCRIPTION
Fix Compilation Issues in Domain Classes

This pull request addresses two specific compilation issues:

1. AuditableEntity Warning
- Added `new` keyword to `CreatedBy` property to resolve warning about hiding inherited member
- Explicitly indicates intentional member hiding

2. Sale Class Money Addition
- Modified `CalculateTotal()` method to use correct Money addition
- Replaced `+=` operator with explicit Money instance creation
- Ensures type-safe money calculations

Changes fix:
- CS0108 warning in AuditableEntity
- CS0019 error in Sale class relating to Money addition

Recommended Next Steps:
- Review changes
- Run full build and test suite
- Verify calculation logic remains consistent