### PR TITLE
Fix Product Class Constructor and CreateProductCommand

### DIFF
--- a/src/IslamicPOS.Application/Products/Commands/CreateProduct/CreateProductCommand.cs
+++ b/src/IslamicPOS.Application/Products/Commands/CreateProduct/CreateProductCommand.cs
@@ -1,4 +1,4 @@
-﻿using IslamicPOS.Domain.Common;
+using IslamicPOS.Domain.Common;
 using IslamicPOS.Domain.Inventory;
 using MediatR;
 using IslamicPOS.Application.Common.Interfaces;
@@ -10,9 +10,11 @@ public record CreateProductCommand : IRequest<Product>
     public string Name { get; init; } = string.Empty;
     public string Description { get; init; } = string.Empty;
     public string SKU { get; init; } = string.Empty;
-    public Money Price { get; init; } = Money.Zero();
+    public decimal Price { get; init; } // Changed from Money to decimal
     public bool IsHalal { get; init; }
     public string HalalCertification { get; init; } = string.Empty;
+    public string Category { get; init; } = string.Empty;
+    public int StockQuantity { get; init; } = 0;
 }
 
 public class CreateProductCommandHandler : IRequestHandler<CreateProductCommand, Product>
@@ -32,7 +34,9 @@ public class CreateProductCommandHandler : IRequestHandler<CreateProductCommand,
             request.SKU,
             request.Price,
             request.IsHalal,
-            request.HalalCertification);
+            request.HalalCertification,
+            request.Category,
+            request.StockQuantity);
 
         _context.Products.Add(product);
         await _context.SaveChangesAsync(cancellationToken);

--- a/src/IslamicPOS.Domain/Inventory/Product.cs
+++ b/src/IslamicPOS.Domain/Inventory/Product.cs
@@ -8,8 +8,30 @@ public class Product : Entity
     public string Description { get; set; } = string.Empty;
     public decimal Price { get; set; }
     public string SKU { get; set; } = string.Empty;
-    public int StockQuantity { get; set; }
+    public int StockQuantity { get; set; } = 0;
     public string Category { get; set; } = string.Empty;
     public bool IsHalal { get; set; }
     public string HalalCertification { get; set; } = string.Empty;
+
+    private Product() {} // For EF Core
+
+    public Product(
+        string name, 
+        string description, 
+        string sku, 
+        decimal price, 
+        bool isHalal, 
+        string halalCertification,
+        string category = "", 
+        int stockQuantity = 0)
+    {
+        Name = name;
+        Description = description;
+        SKU = sku;
+        Price = price;
+        IsHalal = isHalal;
+        HalalCertification = halalCertification;
+        Category = category;
+        StockQuantity = stockQuantity;
+    }
 }


### PR DESCRIPTION
Add Constructor to Product Class and Update CreateProductCommand

This pull request addresses the constructor mismatch between Product and CreateProductCommand:

Changes in Product Class:
- Added a comprehensive constructor
- Included optional parameters for Category and StockQuantity
- Added a private parameterless constructor for EF Core support

Changes in CreateProductCommand:
- Updated properties to match the new Product constructor
- Simplified Price property to decimal type
- Added optional Category and StockQuantity properties

Key Improvements:
- Resolves constructor argument mismatch
- Provides more flexibility in product creation
- Maintains EF Core compatibility

Recommended Next Steps:
- Review constructor signatures
- Verify product creation logic
- Run tests to confirm functionality